### PR TITLE
Add Pyodide web demo for text RPG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # GP
+
 gunpo project. text SF rpg
+
+## Web Demo
+
+`index.html` contains a simple Pyodide-based text RPG. Open it in a browser or run a local server (`python -m http.server`) and navigate to the file to play.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>Pyodide Text RPG</title>
+  <style>
+    body { font-family: sans-serif; background:#111; color:#eee; }
+    pre  { background:#222; padding:10px; height:400px; overflow:auto; }
+    button { margin-top:10px; }
+  </style>
+</head>
+<body>
+  <h1>Pyodide Text RPG 데모</h1>
+  <pre id="output"></pre>
+  <button id="start">게임 시작</button>
+
+  <script type="module">
+    import { loadPyodide } from "https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js";
+
+    const output = document.getElementById("output");
+    const startBtn = document.getElementById("start");
+    let pyodide = null;
+
+    async function initPyodide() {
+      pyodide = await loadPyodide();
+      pyodide.registerJsModule("browser", {
+        write: (text) => output.textContent += text
+      });
+    }
+    initPyodide();
+
+    const gameCode = `
+import random, time, js
+from browser import write
+
+def print(*args, **kwargs):
+    write(" ".join(map(str, args)) + "\n")
+
+def input(prompt=""):
+    return js.prompt(prompt) or ""
+
+class Player:
+    def __init__(self, name):
+        self.name = name
+        self.hp = 100
+        self.attack = 15
+        self.defense = 5
+
+class Enemy:
+    def __init__(self, name, hp, attack, defense):
+        self.name = name
+        self.hp = hp
+        self.attack = attack
+        self.defense = defense
+
+def turn_based_combat(player, enemy):
+    print(f"\n[전투 개시] {player.name} vs {enemy.name}")
+    while player.hp > 0 and enemy.hp > 0:
+        print(f"\n{player.name} HP: {player.hp}, {enemy.name} HP: {enemy.hp}")
+        action = input("행동을 선택하세요 (1: 공격, 2: 방어): ").strip()
+        if action == "1":
+            damage = max(player.attack - enemy.defense, 0)
+            enemy.hp -= damage
+            print(f"{player.name}의 공격! {enemy.name}에게 {damage}만큼의 피해를 입혔습니다.")
+        elif action == "2":
+            print(f"{player.name}는 방어 태세를 취했습니다.")
+            player.defense += 5
+        else:
+            print("잘못된 입력입니다.")
+
+        if enemy.hp <= 0:
+            print(f"{enemy.name}를 처치했습니다!")
+            break
+
+        print(f"{enemy.name}의 차례!")
+        enemy_action = random.choice(["attack", "attack", "attack", "defense"])
+        if enemy_action == "attack":
+            damage = max(enemy.attack - player.defense, 0)
+            player.hp -= damage
+            print(f"{enemy.name}의 공격! {player.name}이 {damage}만큼의 피해를 입었습니다.")
+        else:
+            print(f"{enemy.name}는 방어 태세를 취했습니다.")
+            enemy.defense += 3
+
+        if player.hp <= 0:
+            print(f"{player.name}는 쓰러졌습니다...")
+            break
+
+    player.defense = 5
+
+def mission_office():
+    print("\n[의뢰 사무소] 의뢰가 등록되어 있습니다.")
+    time.sleep(0.5)
+    print("[단말기 알림] 새 임무가 도착했습니다.")
+    time.sleep(0.5)
+    print("내용: 거대 기업의 비밀 연구소 침입.")
+    action = input("임무를 수락하시겠습니까? (y/n): ").strip().lower()
+    return action == "y"
+
+def main():
+    player_name = input("주인공(인공 인간)의 이름을 입력하세요: ")
+    player = Player(player_name)
+    print(f"\n{player.name}가(이) 소모형 인공 인간 용병으로서 깨어났습니다.")
+    print("회사로부터 의뢰를 기다립니다...")
+
+    while player.hp > 0:
+        if mission_office():
+            print("\n임무를 수락했습니다. 현장으로 이동합니다...")
+            enemy = Enemy("경비 드론", 50, 10, 3)
+            turn_based_combat(player, enemy)
+            if player.hp <= 0:
+                print("\n[게임 종료] 당신은 더 이상 임무를 수행할 수 없습니다.")
+            else:
+                print("\n임무 완료! 보상을 받았습니다.")
+                print("의뢰 사무소로 돌아갑니다.\n")
+        else:
+            print("\n임무를 거부했습니다. 다른 의뢰를 기다립니다.")
+            time.sleep(1)
+
+if __name__ == "__main__":
+    main()
+`;
+
+    startBtn.addEventListener("click", async () => {
+      output.textContent = "";
+      await pyodide.runPythonAsync(gameCode);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide Pyodide-based web demo running the text RPG in a browser
- document how to launch the demo

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: the following arguments are required: filenames)*
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6898082c82e0832abaeb349368ea521d