### PR TITLE
Show title screen and display errors in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ gunpo project. text SF rpg
 
 ## Web Demo
 
-`index.html` contains a simple Pyodide-based text RPG. Open it in a browser or run a local server (`python -m http.server`) and navigate to the file to play.
+`index.html` contains a simple Pyodide-based text RPG. Open it in a browser or run a local server (`python -m http.server`) and navigate to the file to play. The output window now shows a title screen when the game starts and displays error messages if something goes wrong.

--- a/index.html
+++ b/index.html
@@ -22,10 +22,14 @@
     let pyodide = null;
 
     async function initPyodide() {
-      pyodide = await loadPyodide();
-      pyodide.registerJsModule("browser", {
-        write: (text) => output.textContent += text
-      });
+      try {
+        pyodide = await loadPyodide();
+        pyodide.registerJsModule("browser", {
+          write: (text) => (output.textContent += text)
+        });
+      } catch (err) {
+        output.textContent += `Pyodide 초기화 실패:\n${err}\n`;
+      }
     }
     initPyodide();
 
@@ -122,8 +126,18 @@ if __name__ == "__main__":
 `;
 
     startBtn.addEventListener("click", async () => {
-      output.textContent = "";
-      await pyodide.runPythonAsync(gameCode);
+      output.textContent = "=== Pyodide Text RPG ===\n";
+
+      if (!pyodide) {
+        output.textContent += "\n[오류] Pyodide가 아직 초기화되지 않았습니다.\n";
+        return;
+      }
+
+      try {
+        await pyodide.runPythonAsync(gameCode);
+      } catch (err) {
+        output.textContent += `\n[에러 발생]\n${err}\n`;
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- show a title header when the game starts
- surface initialization and runtime errors in the browser output
- document new behavior in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68980bc9e034832a95a644c332e9d8ab