### PR TITLE
Remove duplicate formatError definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,22 +70,16 @@
           await typeLine(line);
           await sleep(400);
         }
-      } catch (err) {
-        htmlBuffer += `[오프닝 로드 실패]<br>${formatError(err)}<br>`;
-        output.innerHTML = colorProperNouns(htmlBuffer);
-      }
+    } catch (err) {
+      htmlBuffer += `[오프닝 로드 실패]<br>${formatError(err)}<br>`;
+      output.innerHTML = colorProperNouns(htmlBuffer);
     }
+  }
 
-    function formatError(err) {
-      const code = err?.code || err?.name || "UnknownError";
-      const message = err?.message || err;
-      return `[${code}] ${message}`;
-    }
-
-    async function initPyodide() {
-      try {
-        pyodide = await loadPyodide();
-        pyodide.registerJsModule("browser", {
+  async function initPyodide() {
+    try {
+      pyodide = await loadPyodide();
+      pyodide.registerJsModule("browser", {
           write: (text) => {
             const escaped = escapeHtml(text).replace(/\n/g, "<br>");
             output.innerHTML += colorProperNouns(escaped);


### PR DESCRIPTION
## Summary
- Avoid redeclaration error by keeping a single `formatError` helper in index.html

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899cb360590832aa4625e0d679d803c