### PR TITLE
Fix Pyodide import to use ESM build

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <button id="start">게임 시작</button>
 
   <script type="module">
-    import { loadPyodide } from "https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js";
+    import { loadPyodide } from "https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.mjs";
 
     const output = document.getElementById("output");
     const startBtn = document.getElementById("start");


### PR DESCRIPTION
## Summary
- fix Pyodide import to use ESM build so loadPyodide is available

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689aef7e218c832a8bf7099cb29a7088